### PR TITLE
Update xSushiExchangeRate.sol

### DIFF
--- a/contracts/xSushiExchangeRate.sol
+++ b/contracts/xSushiExchangeRate.sol
@@ -7,9 +7,8 @@ interface IERC20 {
 }
 
 contract xSushiExchangeRate {
-
-  IERC20 xSushi;
-  IERC20 sushi;
+  IERC20 private immutable xSushi;
+  IERC20 private immutable sushi;
 
   constructor(address _xSushi, address _sushi) {
     xSushi = IERC20(_xSushi);
@@ -17,6 +16,14 @@ contract xSushiExchangeRate {
   }
 
   function getExchangeRate() public view returns( uint256 ) {
-    return sushi.balanceOf(address(xSushi))*(10**18) / xSushi.totalSupply();
+    return sushi.balanceOf(address(xSushi))*(1e18) / xSushi.totalSupply();
+  }
+  
+  function toSUSHI(uint256 xSushiAmount) public view returns (uint256 sushiAmount) {
+    sushiAmount = xSushiAmount * sushi.balanceOf(address(xSushi)) / xSushi.totalSupply();
+  }
+  
+  function toXSUSHI(uint256 sushiAmount) public view returns (uint256 xSushiAmount) {
+    xSushiAmount = sushiAmount * xSushi.totalSupply() / sushi.balanceOf(address(xSushi));
   }
 }


### PR DESCRIPTION
Changed tokens to immutable to save 2 SLOADs on every call and 2 SSTOREs on creation.
Added toSUSHI and toXSUSHI: this may be useful?
Left solidity version at ^0.8.0, but it does go against:
https://swcregistry.io/docs/SWC-103
And 0.8.0 may have undiscovered security issues.

These changes are completely untested, just a suggestion.